### PR TITLE
Allow specifying a custom SSH port for ssh-keyscan

### DIFF
--- a/wiki_home/bootstrap_wiki.sh
+++ b/wiki_home/bootstrap_wiki.sh
@@ -8,6 +8,9 @@ SSH_DIRECTORY=$HOME/.ssh
 REPO_PATH=$HOME/web
 WEB_OWNERSHIP=wiki:www-data
 
+# Use SSH port 22 unless is already specified
+SSH_PORT=${SSH_PORT:=22}
+
 # ensure the SSH_DOMAIN and REMOTE_URL envs are set
 [ -z "$SSH_DOMAIN" ] && echo "Need to set SSH_DOMAIN" && exit 1;
 [ -z "$REMOTE_URL" ] && echo "Need to set REMOTE_URL" && exit 1;
@@ -28,7 +31,7 @@ if [ ! -d "$SSH_DIRECTORY" ]; then
 			break
 		else
 			echo "scanning SSH host for keys..."
-			ssh-keyscan $SSH_DOMAIN > $SSH_DIRECTORY/known_hosts
+			ssh-keyscan -p $SSH_PORT $SSH_DOMAIN > $SSH_DIRECTORY/known_hosts
 			sleep 1
 		fi
 	done


### PR DESCRIPTION
Some users might not be using the standard SSH port (22). This change will allow the user to specify a custom port so ssh-keyscan succeeds and continues the repo setup process.