### PR TITLE
Add instant backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ I tried to be cute by combining "Docker" and "Doku". Get it? Hah!
 ### Got any config recommendations?
 I live and die by [indexmenu](https://www.dokuwiki.org/plugin:indexmenu), [upgrade](https://www.dokuwiki.org/plugin:upgrade), and [bootstrap3](https://www.dokuwiki.org/template:bootstrap3). You can install all of these from the built in extension manager in your dockuwiki instance.
 
+### Can I force a backup?
+Sure! Just run ```docker exec -u wiki wiki /home/wiki/backup_once.sh``` to trigger a backup.
 
 ### I’m going on vacation to the moon and won’t have internet access. How can I access my wiki?
 No problemo, moon bound traveler. Either take the machine with you that hosts dockuwiki, or use something like a Raspberry Pi to deploy a new instance with the same repo URL. I don’t suggest running multiple instances simultaneously, but your stand in wiki host will collect all your changes and continue attempting to reach the internet until it is safely back on Earth.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -21,7 +21,7 @@ redirect_stderr=true
 
 [program:wikibak]
 user=wiki
-command=/home/wiki/backup.sh
+command=/home/wiki/backup_hourly.sh
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true

--- a/wiki_home/backup_hourly.sh
+++ b/wiki_home/backup_hourly.sh
@@ -5,18 +5,13 @@ set -e
 
 HOME=/home/wiki
 
-cd /home/wiki/web
+cd /home/wiki
 
 while true
 do
 	echo "Backup script running. Sleeping for 1 hour..."
 	sleep 3600
 
-	echo "Backing up wiki @ `date -u`"
-	git add -A
-	git commit -m "autocommit @ `date -u`"
-
-	git pull origin master
-	git push origin master
+	./backup_once.sh
 done
 

--- a/wiki_home/backup_once.sh
+++ b/wiki_home/backup_once.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# bail out if we hit an error
+set -e
+
+HOME=/home/wiki
+
+cd /home/wiki/web
+
+echo "Backing up wiki @ `date -u`"
+git add -A
+git commit -m "autocommit @ `date -u`"
+
+git pull origin master
+git push origin master

--- a/wiki_home/backup_once.sh
+++ b/wiki_home/backup_once.sh
@@ -9,7 +9,7 @@ cd /home/wiki/web
 
 echo "Backing up wiki @ `date -u`"
 git add -A
-git commit -m "autocommit @ `date -u`"
+git diff-index --quiet HEAD || git commit -m "autocommit @ `date -u`"
 
 git pull origin master
 git push origin master


### PR DESCRIPTION
This way I can be sure the latest changes have been backed up before shutting down the container.

I note that supervisord offers a `TICK_3600` event, which would probably simplify the backup_hourly script, but I didn't change that in this PR.

Resolves #7 